### PR TITLE
Improve usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ services:
 - `TELEGRAM_LOCAL`: If set to `true`, the server will run in local mode. Default is `false`
 
 ## Usage
+After starting the container the API is available on the port configured via `TELEGRAM_HTTP_PORT`. You can verify your setup with:
+
+```bash
+curl http://localhost:8081/bot<token>/getMe
+```
+
+You may also launch the service using Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+The compose configuration keeps bot data in the `./data` directory.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- add a short usage section with curl and docker compose examples

## Testing
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fd8da0274832ca5e98c252eda0f68