### PR TITLE
Update TELEGRAM_LOCAL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ services:
 - `TELEGRAM_DIR`: The directory where the server will store the data. Default is `/data`
 - `TELEGRAM_TEMP_DIR`: The directory where the server will store temporary files. Default is `/tmp`
 - `TELEGRAM_LOG_FILE`: The file where the server will store the logs. Default is `/data/logs/telegram-bot-api.log`
-- `TELEGRAM_LOCAL`: If set to `true`, the server will run in local mode. Default is `false`
+- `TELEGRAM_LOCAL`: Set to `1` or `true` (case-insensitive) to run the server in local mode. Default is `false`
 
 ## Usage
 After starting the container the API is available on the port configured via `TELEGRAM_HTTP_PORT`. You can verify your setup with:

--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - TELEGRAM_API_ID=${TELEGRAM_API_ID}
       - TELEGRAM_API_HASH=${TELEGRAM_API_HASH}
-      - TELEGRAM_LOCAL=1
+      - TELEGRAM_LOCAL=true
     volumes:
       - ./data:/data
       - ./temp:/temp

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ else
 fi
 
 # allow the Bot API server to serve local requests
-if [ "$TELEGRAM_LOCAL" -eq 1 ]; then
+if [ "${TELEGRAM_LOCAL:-}" = "1" ] || [ "$(printf '%s' "${TELEGRAM_LOCAL:-}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
   ARGS="$ARGS --local"
 fi
 


### PR DESCRIPTION
## Summary
- support `1` or `true` for enabling local mode
- document the accepted `TELEGRAM_LOCAL` values
- show usage with `true` in compose file

## Testing
- `sh -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fdb8c29e8832cb01d470ff4082327