### PR TITLE
feat: run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,11 @@ COPY --from=build-stage /telegram-bot-api/bin/ /telegram-bot-api/bin/
 RUN apk update && \
     apk upgrade && \
     apk add --update libstdc++ libgcc && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* && \
+    addgroup -S botapi && adduser -S -G botapi botapi && \
+    chown -R botapi:botapi /telegram-bot-api/bin && \
+    mkdir -p /data /tmp && \
+    chown -R botapi:botapi /data /tmp
 
 WORKDIR /telegram-bot-api/bin
 
@@ -42,5 +46,7 @@ COPY --chmod=755 entrypoint.sh /telegram-bot-api/bin/entrypoint.sh
 
 VOLUME /data/logs
 VOLUME /tmp
+
+USER botapi
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
## Summary
- create dedicated botapi user and group in the final image
- ensure /telegram-bot-api/bin, /data, and /tmp owned by botapi
- run telegram bot api under the non-root user

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48da66534832ca359d12fad2d185c