### PR TITLE
Ensure Telegram API credentials are defined before startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,16 @@ if [ -n "${1}" ]; then
   exec "$@"
 fi
 
+if [ -z "$TELEGRAM_API_ID" ]; then
+  echo "Error: TELEGRAM_API_ID is not set" >&2
+  exit 1
+fi
+
+if [ -z "$TELEGRAM_API_HASH" ]; then
+  echo "Error: TELEGRAM_API_HASH is not set" >&2
+  exit 1
+fi
+
 ARGS=""
 
 # HTTP listening port (default is 8081)


### PR DESCRIPTION
## Summary
- check TELEGRAM_API_ID and TELEGRAM_API_HASH variables before starting the server

## Testing
- `shellcheck entrypoint.sh`
- `sh -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a48daf7f1c832ca686aa041978af5c