### PR TITLE
feat: expose port 8082 and add restart policy

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,8 +4,10 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: telegram-api
+    restart: unless-stopped
     ports:
       - "8081:8081"
+      - "8082:8082"
     environment:
       - TELEGRAM_API_ID=${TELEGRAM_API_ID}
       - TELEGRAM_API_HASH=${TELEGRAM_API_HASH}


### PR DESCRIPTION
## Summary
- map 8082:8082 for telegram-api service
- restart telegram-api unless stopped manually

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48db71a28832c98b7e0963dbd60bf